### PR TITLE
Fix/client entity validation

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -52,8 +52,12 @@ $app->router->post("/users", [$storeUserController, "execute"]);
 
 $app->router->get("/clients", [$indexClientController, "execute"]);
 $app->router->post("/clients", [$storeClientController, "execute"]);
-$app->router->put("/clients", [$updateClientController, "execute"]);
 
-
+/*
+This is the path to update a client,
+The clientId is automatically in $request->params.
+So there is no need to add id in the body of the request, it won't be used
+*/
+$app->router->put("/clients/{clientId}", [$updateClientController, "execute"]);
 
 $app->run();

--- a/src/Core/Utils/Failures/Failure.php
+++ b/src/Core/Utils/Failures/Failure.php
@@ -23,7 +23,7 @@ const DEFAULT_FAILURE_MESSAGES = [
  */
 abstract class Failure extends Exception
 {
-  const DEFAULT_VIEW = "_404";
+  const DEFAULT_VIEW = "_500";
   protected $privateMessage;
   protected $privacy;
   protected $dateTime;

--- a/src/Core/Utils/Failures/ServerFailure.php
+++ b/src/Core/Utils/Failures/ServerFailure.php
@@ -20,7 +20,7 @@ class ServerFailure extends Failure
 
   public function getStatusCode()
   {
-    return self::DEFAULT_VIEW;
+    return self::STATUS_CODE;
   }
 
   public function getStatusText()

--- a/src/Data/Models/ClientModel.php
+++ b/src/Data/Models/ClientModel.php
@@ -9,7 +9,7 @@ class ClientModel extends Client
 {
   const TABLE_NAME = "clients";
 
-  public function __construct($id, string $name, string $contact, $createdAt, $updatedAt)
+  public function __construct($id, $name, $contact, $createdAt, $updatedAt)
   {
     $now = (new DateTime())->getTimestamp();
 

--- a/src/Data/Sources/Clients/MySqlClientSource.php
+++ b/src/Data/Sources/Clients/MySqlClientSource.php
@@ -2,6 +2,7 @@
 
 namespace App\Data\Sources\Clients;
 
+use App\Core\Utils\Failures\NotFoundFailure;
 use App\Data\Sources\Clients\ClientSourceInterface;
 use App\Data\Models\ClientModel;
 use PDO;
@@ -23,7 +24,7 @@ class MySqlClientSource implements ClientSourceInterface
         $statement->execute();
         $clientFetched = $statement->fetchAll(PDO::FETCH_ASSOC);
         return array_map(function ($client) {
-          return new ClientModel($client["id"], $client["name"], $client["contact"], $client["createdAt"], $client["updatedAt"]);
+            return new ClientModel($client["id"], $client["name"], $client["contact"], $client["createdAt"], $client["updatedAt"]);
         }, $clientFetched);
     }
 
@@ -34,9 +35,8 @@ class MySqlClientSource implements ClientSourceInterface
         $statement->execute();
         $fetched = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        // TODO throw new NotFoundException
         if (empty($fetched)) {
-            throw new \Exception();
+            throw new NotFoundFailure("The client with id $id is not found.");
         }
 
         $client = $fetched[0];

--- a/src/Data/UseCases/Clients/UpdateClientUseCase.php
+++ b/src/Data/UseCases/Clients/UpdateClientUseCase.php
@@ -3,9 +3,7 @@
 namespace App\Data\UseCases\Clients;
 
 use App\Core\Utils\Failures\ServerFailure;
-use App\Core\Utils\Strings\RandomString;
 use App\Domain\Repositories\ClientRepositoryInterface;
-use App\Data\Models\ClientModel;
 use App\Core\Utils\Failures\Failure;
 use DateTime;
 

--- a/src/Data/UseCases/Clients/UpdateClientUseCase.php
+++ b/src/Data/UseCases/Clients/UpdateClientUseCase.php
@@ -23,17 +23,36 @@ class UpdateClientUseCase
     try {
       // we get an intance of Client, otherwise an NotFoundFailure will be thrown
       $client = $this->clientRepository->findById($id);
-      
+
       // we use the setters, updatedAt will be updated automatically
       $client->setName($name);
       $client->setContact($contact);
 
-      // then we update on the repository
-      $this->clientRepository->update($client->getId(), $client->getName(), $client->getContact(),  $client->getCreatedAt()->format(DateTime::ATOM), $client->getUpdatedAt()->format(DateTime::ATOM));
+      /*
+      since there is no exception thrown if there is a bad request,
+      we check if there is an error
+      If true, we update it,
+      Otherwise we just the return it, and the controller handle the errors
+      */
+      if ($client->hasErrors()) {
+        // then we update on the repository
+        $this->clientRepository->update(
+          $client->getId(),
+          $client->getName(),
+          $client->getContact(),
+          $client->getCreatedAt()->format(DateTime::ATOM),
+          $client->getUpdatedAt()->format(DateTime::ATOM)
+        );
+      }
 
       // ! lock to make read only
       $client->lock();
 
+      /*
+      Now, the raw format has a errors property
+      if it is empty, it means there is no error
+      Otherwise, it has one, or more
+      */
       return $client->getRaw();
     } catch (\Throwable $th) {
       if ($th instanceof Failure) {

--- a/src/Data/UseCases/Clients/UpdateClientUseCase.php
+++ b/src/Data/UseCases/Clients/UpdateClientUseCase.php
@@ -22,7 +22,7 @@ class UpdateClientUseCase
   {
     try {
       // we get an intance of Client, otherwise an NotFoundFailure will be thrown
-      $client = $this->repository->findById($id);
+      $client = $this->clientRepository->findById($id);
       
       // we use the setters, updatedAt will be updated automatically
       $client->setName($name);

--- a/src/Data/UseCases/Clients/UpdateClientUseCase.php
+++ b/src/Data/UseCases/Clients/UpdateClientUseCase.php
@@ -31,10 +31,10 @@ class UpdateClientUseCase
       /*
       since there is no exception thrown if there is a bad request,
       we check if there is an error
-      If true, we update it,
+      If there is no error, we update it on the repository,
       Otherwise we just the return it, and the controller handle the errors
       */
-      if ($client->hasErrors()) {
+      if (!$client->hasErrors()) {
         // then we update on the repository
         $this->clientRepository->update(
           $client->getId(),

--- a/src/Domain/Entities/Client.php
+++ b/src/Domain/Entities/Client.php
@@ -2,37 +2,114 @@
 
 namespace App\Domain\Entities;
 
+use App\Core\Utils\Failures\ServerFailure;
 use DateTime;
-use Exception;
 
 abstract class Client implements EntityInterface
 {
   const ID_LENGTH = 21;
   const ID_CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
+  const NAME_MIN_LENGTH = 1;
+  const CONTACT_MIN_LENGTH = 1;
 
-  private string $id;
-  private string $name;
-  private string $contact;
-  private DateTime $createdAt;
-  private DateTime $updatedAt;
+  private $id;
+  private $name;
+  private $contact;
+  private $createdAt;
+  private $updatedAt;
 
-  private array $errors;
+  private array $errors = [];
   private bool $locked = false;
 
-  public function __construct($id, string $name, string $contact, DateTime $createdAt, DateTime $updatedAt)
+  /*
+  ! It accepts any type of parameter,
+  ! but it validate them when creating a new instance
+  ! It doesn't throw an exception, but instead, it store in errors
+  ! So use the hasErrors method and set fix the error before saving in a repository
+  ! If id, createdAt, updatedAt are not valid, mostly it's an error from the developers,
+  ! and there is no way to fix it from through this class,
+  ! instead fix the errors and create a new instance
+  */
+  public function __construct($id, $name, $contact, $createdAt, $updatedAt)
   {
     $this->id = $this->validateId($id);
-
-    $this->name = $name;
-    $this->contact = $contact;
-
-    $this->createdAt = $createdAt;
-    $this->updatedAt = $updatedAt;
+    $this->name = $this->validateName($name);
+    $this->contact = $this->validateContact($contact);
+    $this->createdAt = $this->validateCreatedAt($createdAt);
+    $this->updatedAt = $this->validateUpdatedAt($updatedAt);
   }
 
   private function validateId($id)
   {
+    if (!is_string($id)) {
+      $this->addErrorByAttribute("id", "L'identifiant d'un client doit être une chaîne de caractères."); // TODO set to more human readable message
+    }
+
+    if (strlen($id) !== self::ID_LENGTH) {
+      $this->addErrorByAttribute("id", "L'identifiant d'un client doit avoir" . self::ID_LENGTH . " caractères.");
+    }
+
+    if (!$this->containsOnlyChars($id, str_split(self::ID_CHARACTERS))) {
+      $this->addErrorByAttribute("id", "L'identifiant d'un client contient des caractères non autorisées.");
+    }
+
     return $id;
+  }
+
+  private function validateName($name)
+  {
+    $trimmed = trim($name);
+
+    if (!isset($name) || $name === null || empty($trimmed)) {
+      $this->addErrorByAttribute("name", "Le nom du client est obligatoire.");
+    }
+
+    if (!is_string($name)) {
+      $this->addErrorByAttribute("name", "Le nom du client doit être une chaîne de caractères.");
+    }
+
+    if (strlen($trimmed) < self::NAME_MIN_LENGTH) {
+      $this->addErrorByAttribute("name", "La longueur minimale pour le nom du client est de " . self::NAME_MIN_LENGTH . " caractères.");
+    }
+
+    return $trimmed;
+  }
+
+  private function validateContact($contact)
+  {
+    $trimmed = trim($contact);
+
+    if (!isset($contact) || $contact === null || empty($trimmed)) {
+      $this->addErrorByAttribute("contact", "Le contact du client est obligatoire.");
+    }
+
+    if (!is_string($contact)) {
+      $this->addErrorByAttribute("contact", "Le contact du client doit être une chaîne de caractères.");
+    }
+
+    if (strlen($trimmed) < self::CONTACT_MIN_LENGTH) {
+      $this->addErrorByAttribute("contact", "La longueur minimale pour le contact du client est de " . self::CONTACT_MIN_LENGTH . " caractères.");
+    }
+
+    return $trimmed;
+  }
+
+  private function validateCreatedAt($createdAt)
+  {
+    if (!$createdAt instanceof Datetime) {
+      $this->addErrorByAttribute("createdAt", "La date de creation du client n'est pas valide.");
+    }
+
+    return $createdAt;
+  }
+
+  private function validateUpdatedAt($updatedAt)
+  {
+    if (!$updatedAt instanceof Datetime) {
+      $this->addErrorByAttribute("updatedAt", "La date de creation du client n'est pas valide.");
+    }
+
+    return $updatedAt;
   }
 
   public function getId()
@@ -48,10 +125,13 @@ abstract class Client implements EntityInterface
   public function setName($name)
   {
     if ($this->locked) {
-      throw new Exception("instance locked");
+      throw new ServerFailure("instance locked");
     }
 
-    $this->name = $name;
+    // we remove existing errors and validate
+    $this->removeErrorsByAttribute("name");
+    $this->name = $this->validateName($name);
+
     $this->triggerUpdate();
   }
 
@@ -68,10 +148,12 @@ abstract class Client implements EntityInterface
   public function setContact($contact)
   {
     if ($this->locked) {
-      throw new Exception("instance locked");
+      throw new ServerFailure("instance locked");
     }
 
-    $this->contact = $contact;
+    $this->removeErrorsByAttribute("contact");
+    $this->contact = $this->validateContact($contact);
+
     $this->triggerUpdate();
   }
 
@@ -126,8 +208,37 @@ abstract class Client implements EntityInterface
     return $this->errors[$attribute];
   }
 
+  /*
+  if the attribute does not exist in the errors, it will throw a TypeError
+  so use hasError($attribute) before using it
+  */
   public function getFirstError(string $attribute): string
   {
     return $this->errors[$attribute][0];
+  }
+
+  protected function addErrorByAttribute(string $attribute, string $message)
+  {
+    if (array_key_exists($attribute, $this->errors)) {
+      $this->errors[$attribute][] = $message;
+    } else {
+      $this->errors[$attribute] = [$message];
+    }
+  }
+
+  private function containsOnlyChars(string $string, array $allowedChars)
+  {
+    $length = strlen($string);
+    for ($i = 0; $i < $length; $i++) {
+      if (!in_array($string[$i], $allowedChars)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private function removeErrorsByAttribute(string $attribute)
+  {
+    unset($this->errors[$attribute]);
   }
 }

--- a/src/Domain/Entities/Client.php
+++ b/src/Domain/Entities/Client.php
@@ -17,7 +17,7 @@ abstract class Client implements EntityInterface
   private DateTime $updatedAt;
 
   private array $errors;
-  private bool $locked;
+  private bool $locked = false;
 
   public function __construct($id, string $name, string $contact, DateTime $createdAt, DateTime $updatedAt)
   {

--- a/src/Domain/Entities/Client.php
+++ b/src/Domain/Entities/Client.php
@@ -191,7 +191,7 @@ abstract class Client implements EntityInterface
 
   public function hasErrors(): bool
   {
-    return count($this->errors) === 1;
+    return count($this->errors) > 0;
   }
 
   public function getErrors(): array

--- a/src/Domain/Entities/Client.php
+++ b/src/Domain/Entities/Client.php
@@ -174,7 +174,8 @@ abstract class Client implements EntityInterface
       "name" => $this->getName(),
       "contact" => $this->getContact(),
       "createdAt" => $this->getCreatedAt(),
-      "updatedAt" => $this->getUpdatedAt()
+      "updatedAt" => $this->getUpdatedAt(),
+      "errors" => $this->getErrors(), // also add errors as raw
     ];
   }
 

--- a/src/Presentation/Controllers/Clients/UpdateClientController.php
+++ b/src/Presentation/Controllers/Clients/UpdateClientController.php
@@ -26,7 +26,7 @@ class UpdateClientController
     $params = $request->params;
 
     $useCaseResult = $this->updateClientUseCase->execute(
-      $params['clientId'], // the clientId is from $request->params
+      $params['clientId'],
       $body['name'],
       $body['contact']
     );

--- a/src/Presentation/Controllers/Clients/UpdateClientController.php
+++ b/src/Presentation/Controllers/Clients/UpdateClientController.php
@@ -23,8 +23,13 @@ class UpdateClientController
   {
 
     $body = $request->body;
+    $params = $request->params;
 
-    $useCaseResult = $this->updateClientUseCase->execute($body['id'], $body['name'], $body['contact']);
+    $useCaseResult = $this->updateClientUseCase->execute(
+      $params['clientId'], // the clientId is from $request->params
+      $body['name'],
+      $body['contact']
+    );
 
     if ($useCaseResult instanceof Failure) {
       $response->setStatusCode($useCaseResult->getStatusCode());

--- a/src/Presentation/Controllers/Clients/UpdateClientController.php
+++ b/src/Presentation/Controllers/Clients/UpdateClientController.php
@@ -39,10 +39,27 @@ class UpdateClientController
         $response->renderView("_500", ["fatalError" => $useCaseResult->getRaw()]);
       }
     } else {
-      $indexClientUseCase = new IndexClientUseCase($this->updateClientUseCase->getRepository());
-      $clients = $indexClientUseCase->execute();
+      // now we need to handle bad request failure if there is one
 
-      $response->renderView("clients", ["clients" => $clients]);
+      // just to remind, we have a raw format of the client updated, with the new property errors
+      $client = $useCaseResult;
+
+      if (empty($client["errors"])) {
+        // if there is no bad request error, we keep the flow as it is supposed to be
+        $indexClientUseCase = new IndexClientUseCase($this->updateClientUseCase->getRepository());
+        $clients = $indexClientUseCase->execute();
+
+        $response->renderView("clients", ["clients" => $clients]);
+      } else {
+        // otherwise, we send the back the view for editing the client, with the raw client, its (invalid) values , and errors
+        // the goal is to make an error state on the inputs (input with red border, error message on the bottom...)
+
+        $response->setStatusCode(400); // bad request http code
+
+        $response->renderView("editClientView", [
+          "client" => $client
+        ]);
+      }
     }
   }
 }

--- a/src/Presentation/Views/editClientView.php
+++ b/src/Presentation/Views/editClientView.php
@@ -1,5 +1,9 @@
 <?php
-
+/* 
+This file is named editClientView instead of updateClientView because
+the EditClientController (Not implemented yet) use it for its main purpose (editing a client)
+But UpdateClientController can also use it
+*/
 ?>
 
 <form action="<?= "/clients/" . $client["id"] ?>" method="POST">

--- a/src/Presentation/Views/editClientView.php
+++ b/src/Presentation/Views/editClientView.php
@@ -1,0 +1,33 @@
+<?php
+
+?>
+
+<form action="<?= "/clients/" . $client["id"] ?>" method="POST">
+    <input type="hidden" name="_method" value="PUT">
+
+    <!-- TODO add error state to the inputs if errors[<attribute>] exists -->
+
+    <label for="name">Name</label>
+    <input type="text" name="name" id="name" value="<?= $client["name"] ?>">
+
+    <?php if (isset($client["errors"]["name"])): ?>
+        <!--
+            here we just show the first error of the attribute name,
+            but we can show all of them if necessary
+        -->
+        <span style="color:red;">
+            <?= $client["errors"]["name"][0] ?>
+        </span>
+    <?php endif; ?>
+
+    <label for="contact">Contact</label>
+    <input type="text" name="contact" id="contact" value="<?= $client["contact"] ?>">
+
+    <?php if (isset($client["errors"]["contact"])): ?>
+        <span style="color:red;">
+            <?= $client["errors"]["contact"][0] ?>
+        </span>
+    <?php endif; ?>
+
+    <input type="submit" value="Save">
+</form>


### PR DESCRIPTION
# Purpose
The main goal of those changes is to add validations for the Client entity.

# Changes included:
- Set wrong status code for ``ServerFailure`` to ``500``
- Set wrong default view for ``Failure`` (even if it's an abstract class) to ``_500``
- A ``NotFoundFailure`` is thrown if a client is not found from a repository
- Change path for updating a client from ``PUT /clients`` to ``PUT /clients/{clientId}``
- ``Client::__constructor`` accept any type for its parameters but it validate them one by one.
   - So, the ``TypeError`` bug from #5 is fixed with this. And changes from #6 are not necessary.
  - A Client won't throw a BadRequestFailure, but store the errors in ``Client::$errors``:
  eg:
  ```php
  array(2) {
    ["name"]=>
      array(3) {
        [0]=>
        string(33) "Le nom du client est obligatoire."
        [1]=>
        string(55) "Le nom du client doit être une chaîne de caractères."
        [2]=>
        string(64) "La longueur minimale pour le nom du client est de 1 caractères."
      }
    ["contact"]=>
      array(3) {
        [0]=>
        string(37) "Le contact du client est obligatoire."
        [1]=>
        string(59) "Le contact du client doit être une chaîne de caractères."
        [2]=>
        string(68) "La longueur minimale pour le contact du client est de 1 caractères."
      }
    }
  ```
- Add bad request error handling for updating a client
  - The ``UpdateClientUseCase::execute`` performs the update only if there is **no** bad request error
  - The ``UpdateClientController::execute`` handle three case:
    - If there is ServerFailure or NotFoundFailure, it send back a default failure view
    - if the new client has errors (which means there is a bad request error), it send back the editing client view. An example is included.
    - if there is no error, it redirect to appropriate page
   
# TODO
- Handle bad request error in ``StoreClientUseCase::execute`` and ``StoreClientController::execute``

# Enhancement
- ``UpdateClientController::execute`` should **redirect** instead of returning a page if there is no error.
The best case is to redirect to a page that list all orders of the new clients even if it's empty (that's so obvious since the clients has just been created). So the admin can be sure, the client has been created successfully, instead of redirecting to the list of all clients.