### PR TITLE
Revenue per month feature

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -29,6 +29,7 @@ use App\Data\UseCases\Orders\DestroyOrderUseCase;
 use App\Data\UseCases\Bills\DownloadBillUseCase;
 use App\Data\UseCases\Clients\ShowClientUseCase;
 use App\Data\UseCases\Home\ShowHomeUseCase;
+use App\Data\UseCases\Revenues\IndexRevenueUseCase;
 use App\Presentation\Controllers\Clients\IndexClientController;
 use App\Presentation\Controllers\Clients\StoreClientController;
 use App\Presentation\Controllers\Clients\UpdateClientController;
@@ -48,6 +49,7 @@ use App\Presentation\Controllers\Orders\ShowOrderController;
 use App\Presentation\Controllers\Orders\DestroyOrderController;
 use App\Presentation\Controllers\Bills\DownloadBillController;
 use App\Presentation\Controllers\Clients\EditClientController;
+use App\Presentation\Controllers\Revenues\IndexRevenueController;
 
 $dotenv = Dotenv::createImmutable(__DIR__ . "/../");
 $dotenv->load();
@@ -134,6 +136,10 @@ $downloadBillController = new DownloadBillController($downloadBillUseCase);
 $showHomeUseCase = new ShowHomeUseCase($clientRepository, $carRepository, $orderRepository);
 $showHomeController = new ShowHomeController($showHomeUseCase);
 
+// Revenues
+$indexRevenueUseCase = new IndexRevenueUseCase($orderRepository);
+$indexRevenueController = new IndexRevenueController($indexRevenueUseCase);
+
 $app = new Application();
 
 $app->router->post("/users", [$storeUserController, "execute"]);
@@ -178,5 +184,8 @@ $app->router->get("/orders/{orderId}", [$showOrderController, "execute"]);
 
 // Bills routes
 $app->router->get("/bills/{orderId}/download", [$downloadBillController, "execute"]);
+
+// Revenue routes
+$app->router->get("/revenues", [$indexRevenueController, "execute"]);
 
 $app->run();

--- a/src/Data/Repositories/OrderRepository.php
+++ b/src/Data/Repositories/OrderRepository.php
@@ -73,6 +73,6 @@ class OrderRepository implements OrderRepositoryInterface
 
     public function getRevenuePerMonthByLastMonths(int $lastMonths): array
     {
-        return $this->source->getRevenuePerMonthByLastMonths();
+        return $this->source->getRevenuePerMonthByLastMonths($lastMonths);
     }
 }

--- a/src/Data/Repositories/OrderRepository.php
+++ b/src/Data/Repositories/OrderRepository.php
@@ -65,4 +65,14 @@ class OrderRepository implements OrderRepositoryInterface
     {
         return $this->source->getRevenueByLastMonths($lastMonths);
     }
+
+    public function getRevenuePerMonth(): array
+    {
+        return $this->source->getRevenuePerMonth();
+    }
+
+    public function getRevenuePerMonthByLastMonths(int $lastMonths): array
+    {
+        return $this->source->getRevenuePerMonthByLastMonths();
+    }
 }

--- a/src/Data/Sources/Orders/MySqlOrderSource.php
+++ b/src/Data/Sources/Orders/MySqlOrderSource.php
@@ -530,13 +530,13 @@ class MySqlOrderSource implements OrderSourceInterface
             $monthsDiff = $interval->m + ($interval->y * 12) + 1;
 
             $dateAmountAssocDefault[$maxCreatedAt->format(DateTime::ATOM)] = [
-                "date" => $maxCreatedAt->format(DateTime::ATOM),
+                "date" => new DateTime($maxCreatedAt->format(DateTime::ATOM)),
                 "amount" => 0
             ];
             for ($i = 0; $i < $monthsDiff - 1; $i++) {
                 $maxCreatedAt->modify("-1 month");
                 $dateAmountAssocDefault[$maxCreatedAt->format(DateTime::ATOM)] = [
-                    "date" => $maxCreatedAt->format(DateTime::ATOM),
+                    "date" => new DateTime($maxCreatedAt->format(DateTime::ATOM)),
                     "amount" => 0
                 ];
             }
@@ -633,13 +633,13 @@ class MySqlOrderSource implements OrderSourceInterface
         $now->modify("first day of this month");
         $now->setTime(0, 0, 0, 0);
         $dateAmountAssocDefault[$now->format(DateTime::ATOM)] = [
-            "date" => $now->format(DateTime::ATOM),
+            "date" => new DateTime($now->format(DateTime::ATOM)),
             "amount" => 0
         ];
         for ($i = 0; $i < $lastMonths - 1; $i++) {
             $now->modify("-1 month");
             $dateAmountAssocDefault[$now->format(DateTime::ATOM)] = [
-                "date" => $now->format(DateTime::ATOM),
+                "date" => new DateTime($now->format(DateTime::ATOM)),
                 "amount" => 0
             ];
         }

--- a/src/Data/Sources/Orders/MySqlOrderSource.php
+++ b/src/Data/Sources/Orders/MySqlOrderSource.php
@@ -353,38 +353,37 @@ class MySqlOrderSource implements OrderSourceInterface
         return array_values(
             array_map(
                 function ($orderArr) {
-                    return (
-                        new OrderModel(
-                            $orderArr["id"],
-                            new ClientModel(
-                                $orderArr["client"]["id"],
-                                $orderArr["client"]["name"],
-                                $orderArr["client"]["contact"],
-                                $orderArr["client"]["createdAt"],
-                                $orderArr["client"]["updatedAt"]
-                            ),
-                            array_map(
-                                function ($carIdArr) {
-                                            $car = $carIdArr["car"];
-                                            $quantity = $carIdArr["quantity"];
+                    return (new OrderModel(
+                        $orderArr["id"],
+                        new ClientModel(
+                            $orderArr["client"]["id"],
+                            $orderArr["client"]["name"],
+                            $orderArr["client"]["contact"],
+                            $orderArr["client"]["createdAt"],
+                            $orderArr["client"]["updatedAt"]
+                        ),
+                        array_map(
+                            function ($carIdArr) {
+                                $car = $carIdArr["car"];
+                                $quantity = $carIdArr["quantity"];
 
-                                            return [
-                                                "car" => new CarModel(
-                                                    $car["id"],
-                                                    $car["name"],
-                                                    $car["price"],
-                                                    $car["inStock"],
-                                                    $car["createdAt"],
-                                                    $car["updatedAt"],
-                                                ),
-                                                "quantity" => $quantity
-                                            ];
-                                        },
-                                array_values($orderArr["cars"])
-                            ),
-                            $orderArr["createdAt"],
-                            $orderArr["updatedAt"]
-                        )
+                                return [
+                                    "car" => new CarModel(
+                                        $car["id"],
+                                        $car["name"],
+                                        $car["price"],
+                                        $car["inStock"],
+                                        $car["createdAt"],
+                                        $car["updatedAt"],
+                                    ),
+                                    "quantity" => $quantity
+                                ];
+                            },
+                            array_values($orderArr["cars"])
+                        ),
+                        $orderArr["createdAt"],
+                        $orderArr["updatedAt"]
+                    )
                     );
                 },
                 $orderIdArr
@@ -497,5 +496,188 @@ class MySqlOrderSource implements OrderSourceInterface
             },
             0
         );
+    }
+
+    public function getRevenuePerMonth(): array
+    {
+        $orderTableName = OrderModel::TABLE_NAME;
+        $carTableName = CarModel::TABLE_NAME;
+        $orderCarsTableName = "order_cars";
+
+        $statement = $this->pdo->prepare(
+            "SELECT
+                MAX(createdAt) AS maxCreatedAt,
+                MIN(createdAt) AS minCreatedAt
+            FROM $orderTableName;"
+        );
+        $statement->execute();
+        $arrayFetched = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        $dateAmountAssocDefault = [];
+
+        // if there is one or more order
+        if (!empty($arrayFetched)) {
+
+            $minMaxCreatedAt = $arrayFetched[0];
+            $minCreatedAt = new DateTime($minMaxCreatedAt["minCreatedAt"]);
+            $minCreatedAt->modify("first day of this month");
+            $minCreatedAt->setTime(0, 0, 0, 0);
+            $maxCreatedAt = new DateTime($minMaxCreatedAt["maxCreatedAt"]);
+            $maxCreatedAt->modify("first day of this month");
+            $maxCreatedAt->setTime(0, 0, 0, 0);
+
+            $interval = $minCreatedAt->diff($maxCreatedAt);
+            $monthsDiff = $interval->m + ($interval->y * 12) + 1;
+
+            $dateAmountAssocDefault[$maxCreatedAt->format(DateTime::ATOM)] = [
+                "date" => $maxCreatedAt->format(DateTime::ATOM),
+                "amount" => 0
+            ];
+            for ($i = 0; $i < $monthsDiff - 1; $i++) {
+                $maxCreatedAt->modify("-1 month");
+                $dateAmountAssocDefault[$maxCreatedAt->format(DateTime::ATOM)] = [
+                    "date" => $maxCreatedAt->format(DateTime::ATOM),
+                    "amount" => 0
+                ];
+            }
+
+            $statement = $this->pdo->prepare(
+                "SELECT
+                    $carTableName.price,
+                    $orderCarsTableName.quantity,
+                    $orderTableName.createdAt
+                FROM $orderTableName
+                INNER JOIN $orderCarsTableName
+                    ON $orderTableName.id = $orderCarsTableName.orderId
+                INNER JOIN $carTableName
+                    ON $orderCarsTableName.carId = $carTableName.id
+                ;"
+            );
+
+            $statement->execute();
+
+            $arrayFetched = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+            $dateAmountAssocFetched = $this->createDateAmountFromArrayFetched($arrayFetched);
+
+            // we merge them
+            foreach ($dateAmountAssocFetched as $key => $value) {
+                if (array_key_exists($key, $dateAmountAssocDefault)) {
+                    $dateAmountAssocDefault[$key]["amount"] = $value["amount"];
+                }
+            }
+        }
+
+        $dateAmountValue = array_values($dateAmountAssocDefault);
+
+        return $dateAmountValue;
+    }
+
+    public function getRevenuePerMonthByLastMonths(int $lastMonths): array
+    {
+        $orderTableName = OrderModel::TABLE_NAME;
+        $carTableName = CarModel::TABLE_NAME;
+        $orderCarsTableName = "order_cars";
+
+        $whereQuery = "";
+
+        if ($lastMonths > 1) {
+            $whereQuery = "WHERE
+            $orderTableName.createdAt BETWEEN DATE_ADD(
+                DATE_SUB(
+                    CURDATE(),
+                    INTERVAL :lastMonths MONTH
+                ),
+                INTERVAL - DAY(
+                    DATE_SUB(
+                        CURDATE(),
+                        INTERVAL :lastMonths MONTH
+                    )
+                ) + 1 DAY
+            )
+            AND LAST_DAY(NOW())";
+        } else {
+            $whereQuery = "WHERE
+                MONTH($orderTableName.createdAt) = MONTH(CURDATE())
+            AND 
+                YEAR($orderTableName.createdAt) = YEAR(CURDATE())";
+        }
+
+        $statement = $this->pdo->prepare(
+            "SELECT
+                $carTableName.price,
+                $orderCarsTableName.quantity,
+                $orderTableName.createdAt
+            FROM $orderTableName
+            INNER JOIN $orderCarsTableName
+                ON $orderTableName.id = $orderCarsTableName.orderId
+            INNER JOIN $carTableName
+                ON $orderCarsTableName.carId = $carTableName.id
+            $whereQuery
+            ;"
+        );
+
+        if ($lastMonths > 1) {
+            $statement->bindValue("lastMonths", $lastMonths);
+        }
+
+        $statement->execute();
+
+        // we fetch from the db
+        $arrayFetched = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $dateAmountAssocFetched = $this->createDateAmountFromArrayFetched($arrayFetched);
+
+        // we create the default result
+        $dateAmountAssocDefault = [];
+        $now = new DateTime();
+        $now->modify("first day of this month");
+        $now->setTime(0, 0, 0, 0);
+        $dateAmountAssocDefault[$now->format(DateTime::ATOM)] = [
+            "date" => $now->format(DateTime::ATOM),
+            "amount" => 0
+        ];
+        for ($i = 0; $i < $lastMonths - 1; $i++) {
+            $now->modify("-1 month");
+            $dateAmountAssocDefault[$now->format(DateTime::ATOM)] = [
+                "date" => $now->format(DateTime::ATOM),
+                "amount" => 0
+            ];
+        }
+
+        // we merge them
+        foreach ($dateAmountAssocFetched as $key => $value) {
+            if (array_key_exists($key, $dateAmountAssocDefault)) {
+                $dateAmountAssocDefault[$key]["amount"] = $value["amount"];
+            }
+        }
+
+        $dateAmountValue = array_values($dateAmountAssocDefault);
+
+        return $dateAmountValue;
+    }
+
+    /* It creates an associative array with date and amount as keys*/
+    private function createDateAmountFromArrayFetched($arrayFetched)
+    {
+
+        $dateAmountAssocFetched = [];
+
+        foreach ($arrayFetched as $fetched) {
+            $firstDate = new DateTime($fetched["createdAt"]);
+            $firstDate->modify("first day of this month");
+            $firstDate->setTime(0, 0, 0, 0);
+            $dateString = $firstDate->format(DateTime::ATOM);
+
+            if (array_key_exists($dateString, $dateAmountAssocFetched)) {
+                $dateAmountAssocFetched[$dateString]["amount"] += $fetched["price"] * $fetched["quantity"];
+            } else {
+                $dateAmountAssocFetched[$dateString] = [
+                    "amount" => $fetched["price"] * $fetched["quantity"],
+                    "date" => $firstDate
+                ];
+            }
+        }
+
+        return $dateAmountAssocFetched;
     }
 }

--- a/src/Data/Sources/Orders/OrderSourceInterface.php
+++ b/src/Data/Sources/Orders/OrderSourceInterface.php
@@ -13,6 +13,8 @@ interface OrderSourceInterface
     public function getCountByLastMonths(int $lastMonths): int;
     public function getRevenue(): int;
     public function getRevenueByLastMonths(int $lastMonths): int;
+    public function getRevenuePerMonth(): array;
+    public function getRevenuePerMonthByLastMonths(int $lastMonths): array;
     public function findByClientId(string $clientId): array;
     public function save(string $id, string $clientId, array $orderCarsIds, array $carsIds, array $quantities, string $createdAt, string $updatedAt): void;
     public function update(string $id, string $clientId, array $orderCarsIds, array $carsIds, array $quantities, string $createdAt, string $updatedAt): void;

--- a/src/Data/UseCases/Revenues/IndexRevenueUseCase.php
+++ b/src/Data/UseCases/Revenues/IndexRevenueUseCase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Data\UseCases\Revenues;
+
+use App\Core\Utils\Failures\ServerFailure;
+use App\Domain\Repositories\OrderRepositoryInterface;
+use App\Core\Utils\Failures\Failure;
+
+class IndexRevenueUseCase
+{
+    private OrderRepositoryInterface $orderRepository;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+    ) {
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function execute()
+    {
+        try {
+            // ! we get only the last 6 months
+            $revenuePerMonthForLast6Months = $this->orderRepository->getRevenuePerMonthByLastMonths(6);
+
+            return [
+                "revenuePerMonthForLast6Months" => $revenuePerMonthForLast6Months
+            ];
+        } catch (\Throwable $th) {
+            if ($th instanceof Failure) {
+                return $th;
+            } else {
+                return new ServerFailure();
+            }
+        }
+    }
+}

--- a/src/Domain/Repositories/OrderRepositoryInterface.php
+++ b/src/Domain/Repositories/OrderRepositoryInterface.php
@@ -13,6 +13,8 @@ interface OrderRepositoryInterface
     public function getCountByLastMonths(int $lastMonths): int;
     public function getRevenue(): int;
     public function getRevenueByLastMonths(int $lastMonths): int;
+    public function getRevenuePerMonth(): array;
+    public function getRevenuePerMonthByLastMonths(int $lastMonths): array;
     public function findByClientId(string $clientId): array;
     // public function findByCarId(string $carId): array; // require more time to implement and maybe not necessary
     public function save(string $id, string $clientId, array $orderCarsIds, array $carsIds, array $quantities, string $createdAt, string $updatedAt): void;

--- a/src/Presentation/Controllers/Revenues/IndexRevenueController.php
+++ b/src/Presentation/Controllers/Revenues/IndexRevenueController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Presentation\Controllers\Orders;
+
+use App\Core\Requests\Request;
+use App\Core\Responses\Response;
+use App\Core\Utils\Failures\Failure;
+use App\Core\Utils\Failures\NotFoundFailure;
+use App\Core\Utils\Failures\ServerFailure;
+use App\Data\UseCases\Revenues\IndexRevenueUseCase;
+
+class IndexRevenueController
+{
+    private IndexRevenueUseCase $indexRevenueUseCase;
+
+    public function __construct(IndexRevenueUseCase $indexRevenueUseCase)
+    {
+        $this->indexRevenueUseCase = $indexRevenueUseCase;
+    }
+
+    public function execute(Request $request, Response $response)
+    {
+        $useCaseResult = $this->indexRevenueUseCase->execute();
+
+        if ($useCaseResult instanceof Failure) {
+            $response->setStatusCode($useCaseResult->getStatusCode());
+            if ($useCaseResult instanceof NotFoundFailure) {
+                $response->renderView(
+                    "_404",
+                    [
+                        "fatalError" => $useCaseResult->getRaw()
+                    ]
+                );
+            } else if ($useCaseResult instanceof ServerFailure) {
+                $response->renderView(
+                    "_500",
+                    [
+                        "fatalError" => $useCaseResult->getRaw()
+                    ]
+                );
+            }
+        } else {
+            $revenuePerMonthForLast6Months = $useCaseResult["revenuePerMonthForLast6Months"];
+
+            $response->renderView(
+                "revenues/index",
+                [
+                    "revenuePerMonthForLast6Months" => $revenuePerMonthForLast6Months
+                ]
+            );
+        }
+    }
+}

--- a/src/Presentation/Controllers/Revenues/IndexRevenueController.php
+++ b/src/Presentation/Controllers/Revenues/IndexRevenueController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Presentation\Controllers\Orders;
+namespace App\Presentation\Controllers\Revenues;
 
 use App\Core\Requests\Request;
 use App\Core\Responses\Response;

--- a/src/Presentation/Views/revenues/index.php
+++ b/src/Presentation/Views/revenues/index.php
@@ -1,0 +1,12 @@
+<?php
+use App\Core\Utils\Strings\FormatCurrency;
+?>
+
+<ul>
+    <?php foreach($revenuePerMonthForLast6Months as $dateAmount): ?>
+        <li>
+            <p><?= $dateAmount["date"]->format("F Y") ?></p>
+            <p><?= FormatCurrency::format($dateAmount["amount"]) ?></p>
+        </li>
+    <?php endforeach; ?>
+</ul>


### PR DESCRIPTION
Add revenue per month feature.
It considers only the **last 6 months** but can be changed to get all revenues.
e.g: If today is the **3 April 2023**, it consider all revenues between the **1 November 2022** and the **3 April 2023**.
- Create IndexRevenueUseCase
- Create IndexRevenueController  